### PR TITLE
ci: run test on pull_request (without _target)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     branches:
       - main
 


### PR DESCRIPTION
Repository settings disallows non-maintainers to run actions in this
repo without explicit permissions, so I think this should be okay.

This allows the test to actually test new functionality.