### PR TITLE
fix missing slash readme cleanup

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -373,7 +373,7 @@ jobs:
         with:
           repository: nrkno/github-workflow-terraform-config
           ref: ${{ needs.setup.outputs.workflow_tag }}
-          path: ${{ env.GITHUB_WORKSPACE }}.github-workflow-terraform-config
+          path: ${{ env.GITHUB_WORKSPACE }}/.github-workflow-terraform-config
       - name: Set configuration
         id: set_config
         shell: bash
@@ -386,12 +386,12 @@ jobs:
             echo "::set-output name=terraformdocsconfig::${GITHUB_WORKSPACE}${REPO_NAME}/.terraform-docs.yaml"
           else
             echo "Using workflow configuration for commitlint"
-            echo "::set-output name=terraformdocsconfig::${GITHUB_WORKSPACE}.github-workflow-terraform-config/.terraform-docs.yaml"
+            echo "::set-output name=terraformdocsconfig::${GITHUB_WORKSPACE}/.github-workflow-terraform-config/.terraform-docs.yaml"
           fi
       - name: Render terraform docs and push
         uses: terraform-docs/gh-actions@v1.0.0
         with:
-          find-dir: ${{ env.GITHUB_WORKSPACE }}${{ needs.get_repo.outputs.REPO_NAME }}/
+          find-dir: ${{ env.GITHUB_WORKSPACE }}/${{ needs.get_repo.outputs.REPO_NAME }}/
           config-file: ${{ steps.set_config.outputs.terraformdocsconfig }}
           output-file: ${{ inputs.terraform-docs-output-file }}
           output-method: ${{ inputs.terraform-docs-output-method }}

--- a/README.md
+++ b/README.md
@@ -54,6 +54,27 @@ jobs:
       # Set environment variable ARM_THREEPOINTZERO_BETA_RESOURCES=true when running Terraform.
       # Default: false
       enable-azurerm-3-beta-resources: false
+      # Enable job to automaticly create terraform doc from terraform-code
+      # More documentation can be found here: https://github.com/terraform-docs/gh-actions#configuration
+      # default: true
+      terraform-docs-job-enabled:
+      # Set path and filename of terraform-docs config file.
+      # If no file pressent in action-repo, it will get configfile from this repo
+      # More documentation can be found here: https://terraform-docs.io/user-guide/configuration/
+      # Default: .terraform-docs.yaml
+      terraform-docs-config-file:
+      # Which file to output the rendered result
+      # Default: README.md
+      terraform-docs-output-file:
+      # How to inject result
+      # Default: inject
+      terraform-docs-output-method:
+      # What message this step should commit it changes to output-file with
+      # Default: "docs: terraform-docs automated update"
+      terraform-docs-git-commit-message:
+      # To enable this step to push its changes to working-branch
+      # Default: true
+      terraform-docs-git-push:
     secrets:
       # A semicolon separated list of Terraform registry credentials per domain.
       # Format: domain1.example.com=token1;domain2.example.com=token2


### PR DESCRIPTION
- docs: add documentation for new inputs related to terraform-docs
- ci: add missing / to path of remote .terraform-docs.yaml file and checkout directory of github-workflow-terraform-config
