### PR TITLE
ssh deploy key for update, git add fixes for docs and recursive doc update by default

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,7 @@ jobs:
     with:
       working-directory: ./test/terraform
       runs-on: ubuntu-latest
+      terraform-docs-fail-on-diff: false
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
       ssh-private-key: ${{ secrets.SSH_KEY_GITHUB_ACTIONS }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -381,14 +381,14 @@ jobs:
         id: set_config
         shell: bash
         env:
-          SOURCE_PATH: ${{ env.GITHUB_WORKSPACE }}/source/${{ inputs.working-directory }}
+          CONFIG_FILE: ${{ inputs.terraform-docs-config-file }}
         run: |
-          if [ -f "source/.terraform-docs.yaml" ]
+          if [ -f "$CONFIG_FILE" ]
           then
             echo "Using callers configuration for commitlint"
           else
             echo "Using workflow configuration for commitlint"
-            cp -- "${GITHUB_WORKSPACE}/.github-workflow-terraform-config/.terraform-docs.yaml" .terraform-docs.yaml
+            cp -- "${GITHUB_WORKSPACE}/.github-workflow-terraform-config/.terraform-docs.yaml" "$CONFIG_FILE"
           fi
       - name: Remove workflow checkout
         shell: bash
@@ -398,7 +398,7 @@ jobs:
         uses: terraform-docs/gh-actions@v1.0.0
         with:
           working-dir: ${{ inputs.working-directory }}
-          config-file: .terraform-docs.yaml
+          config-file: ${{ inputs.terraform-docs-config-file }}
           output-file: ${{ inputs.terraform-docs-output-file }}
           output-method: ${{ inputs.terraform-docs-output-method }}
           git-commit-message: ${{ inputs.terraform-docs-git-commit-message }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -60,7 +60,7 @@ on:
         default: true
       terraform-docs-fail-on-diff:
         type: boolean
-        default: false
+        default: true
       terraform-docs-recursive:
         type: boolean
         default: false

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -58,7 +58,9 @@ on:
       terraform-docs-git-push:
         type: boolean
         default: true
-
+      terraform-docs-fail-on-diff:
+        type: boolean
+        default: false
       # Toggles used for setting environment variables in this workflow.
       # It is not possible to pass env vars directly to reusable workflows.
       enable-azurerm-3-beta-resources:
@@ -69,6 +71,8 @@ on:
         required: false
       ssh-private-key:
         required: true
+      ssh-private-key-docs-push:
+        required: false
       token:
         required: true
 
@@ -355,8 +359,28 @@ jobs:
     needs: [terraform]
     concurrency: terraform-docs
     steps:
+      - name: Check ssh key for checkout and push
+        id: ssh_key_check
+        shell: bash
+        env:
+          SSH_PRIVATE_KEY: "${{ secrets.ssh-private-key-docs-push }}"
+        run: |
+          set +e
+          if test -n "${SSH_PRIVATE_KEY}"
+          then
+            echo "::set-output name=has_ssh_key::yes"
+          else
+            echo "::set-output name=has_ssh_key::no"
+          fi
       - name: Checkout
         uses: actions/checkout@v3
+        if: ${{ steps.ssh_key_check.outputs.has_ssh_key == 'yes' }}
+        with:
+          ref: "${{ github.head_ref }}"
+          ssh-key: "${{ secrets.ssh-private-key-docs-push }}"
+      - name: Checkout
+        uses: actions/checkout@v3
+        if: ${{ steps.ssh_key_check.outputs.has_ssh_key  != 'yes' }}
         with:
           ref: "${{ github.head_ref }}"
       - name: Checkout workflow
@@ -390,6 +414,8 @@ jobs:
             echo "Using workflow configuration for commitlint"
             cp -- "${GITHUB_WORKSPACE}/.github-workflow-terraform-config/.terraform-docs.yaml" "$CONFIG_FILE"
           fi
+          # workaround for terraform docs trigger happy git add
+          echo "$CONFIG_FILE" >> .gitignore
       - name: Remove workflow checkout
         shell: bash
         run: |
@@ -399,7 +425,27 @@ jobs:
         with:
           working-dir: ${{ inputs.working-directory }}
           config-file: ${{ inputs.terraform-docs-config-file }}
+          fail-on-diff: ${{ inputs.terraform-docs-fail-on-diff }}
           output-file: ${{ inputs.terraform-docs-output-file }}
           output-method: ${{ inputs.terraform-docs-output-method }}
-          git-commit-message: ${{ inputs.terraform-docs-git-commit-message }}
-          git-push: ${{ inputs.terraform-docs-git-push }}
+          git-push: false
+      - name: Commit doc updates
+        if: ${{ steps.ssh_key_check.outputs.has_ssh_key == 'yes' && inputs.terraform-docs-git-push }}
+        shell: bash
+        env:
+          COMMIT_MESSAGE: ${{ inputs.terraform-docs-git-commit-message }}
+        run: |
+          # restore gitignore workaround
+          git checkout .gitignore
+          if [ $(git status --porcelain | grep -c -E '*.\.md$') -eq 0 ]
+          then
+            echo "No changes to .md files"
+            exit 0
+          fi
+          # sometimes cleanup fails, workaround
+          sudo chown -R -- $(id -u) .git
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add $(git status --porcelain | awk '/.*\.md$/ { print $2 }')
+          git commit -m "$COMMIT_MESSAGE"
+          git push

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -61,6 +61,9 @@ on:
       terraform-docs-fail-on-diff:
         type: boolean
         default: false
+      terraform-docs-recursive:
+        type: boolean
+        default: false
       # Toggles used for setting environment variables in this workflow.
       # It is not possible to pass env vars directly to reusable workflows.
       enable-azurerm-3-beta-resources:
@@ -426,6 +429,7 @@ jobs:
           working-dir: ${{ inputs.working-directory }}
           config-file: ${{ inputs.terraform-docs-config-file }}
           fail-on-diff: ${{ inputs.terraform-docs-fail-on-diff }}
+          recursive: ${{ inputs.terraform-docs-recursive }}
           output-file: ${{ inputs.terraform-docs-output-file }}
           output-method: ${{ inputs.terraform-docs-output-method }}
           git-push: false

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ jobs:
       # to fail when there are documentation changes
       # Default: false
       terraform-docs-fail-on-diff: false
+      # If true it will update submodules recursively in the directory modules under working directory
+      # Default: false
+      terraform-docs-recursive: false
     secrets:
       # A semicolon separated list of Terraform registry credentials per domain.
       # Format: domain1.example.com=token1;domain2.example.com=token2

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ jobs:
       terraform-docs-git-push: true
       # to fail when there are documentation changes
       # Default: false
-      terraform-docs-fail-on-diff: false
+      terraform-docs-fail-on-diff: true
       # If true it will update submodules recursively in the directory modules under working directory
       # Default: false
       terraform-docs-recursive: false
@@ -93,9 +93,30 @@ jobs:
       # trigger workflows, the push needs to be done using ssh key
       # See https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
       # for more information
-      ssh-private-key-docs-push: ${{ secret.SSH_KEY_DOCS_PUSH }}
+      ssh-private-key-docs-push: ${{ secret.SSH_KEY_TERRAFORM_DOCS }}
       # Must be specified to post status comments to incoming PR's.
       token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Setting up automatic push of terraform documentation updates
+
+In order to get updates of terraform documentation to trigger new workflows, the
+git push must be done using a ssh deploy key and not the build in github token.
+You first need to generate a new ssh key pair and add build secrets:
+```bash
+ssh-keygen -f id_ed25519 -t ed25519 -N "" -C "terraform-docs"
+gh repo deploy-key add -w -t "terraform docs push" id_ed25519.pub
+gh secret set SSH_KEY_TERRAFORM_DOCS -b "$(cat id_ed25519)"
+gh secret set SSH_KEY_TERRAFORM_DOCS -b "$(cat id_ed25519)" --app dependabot
+shred -u id_ed25519*
+```
+Then change inputs for the workflow and set
+```yaml
+    with:
+      ...
+      terraform-docs-fail-on-diff: false
+    secrets:
+      ssh-private-key-docs-push: ${{ secret.SSH_KEY_TERRAFORM_DOCS }}
 ```
 
 ## Developing

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ jobs:
       # https://aquasecurity.github.io/trivy/v0.29.2/docs/vulnerability/examples/filter/#by-vulnerability-ids
       # Default: ""
       trivy-ignore-files: .trivyignore
-      # Generate a Software Bill Of Materials (SBOM) report in table format. 
+      # Generate a Software Bill Of Materials (SBOM) report in table format.
       # Default: false
       trivy-sbom-enabled: false
       # Comma-separated list of Severity levels that should trigger errors.
@@ -73,8 +73,12 @@ jobs:
       # Default: "docs: terraform-docs automated update"
       terraform-docs-git-commit-message:
       # To enable this step to push its changes to working-branch
+      # Requires that ssh-private-key-docs-push is set
       # Default: true
-      terraform-docs-git-push:
+      terraform-docs-git-push: true
+      # to fail when there are documentation changes
+      # Default: false
+      terraform-docs-fail-on-diff: false
     secrets:
       # A semicolon separated list of Terraform registry credentials per domain.
       # Format: domain1.example.com=token1;domain2.example.com=token2
@@ -82,6 +86,11 @@ jobs:
       registries: "my-registry.example.com=${{ secrets.MY_REGISTRY_TOKEN }};second.registry.example.com=${{ secret.SECOND_REGISTRY }}"
       # Must be specified if using Terraform modules from private git repos.
       ssh-private-key: ${{ secrets.SSH_KEY_GITHUB_ACTIONS }}
+      # In order to push updates from terraform docs and let the push
+      # trigger workflows, the push needs to be done using ssh key
+      # See https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+      # for more information
+      ssh-private-key-docs-push: ${{ secret.SSH_KEY_DOCS_PUSH }}
       # Must be specified to post status comments to incoming PR's.
       token: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
This will hopefully fix the workflow issues once and for all. For explaination see https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs

Short story, git push using the generated token does not trigger new workflow runs. We thus change this workflow to require a ssh deploy for push, otherwise do not push. We also have a new option to fail on changes, so that can be used as an alternative.

This PR also fixes the trigger happy commit by the docs action which will commit the `.terraform-docs.yaml` file even though it should not.

Also includes new feature turned off by default, recursive update of modules path.