### PR TITLE
Add workflow-ref input to fix local tests

### DIFF
--- a/.github/workflows/autodoc.yaml
+++ b/.github/workflows/autodoc.yaml
@@ -20,10 +20,6 @@ jobs:
         with:
           python-version: 3.11
       -
-        name: Install dependencies
-        run: |
-          python -m pip install -U pyyaml
-      -
         name: Checkout
         uses: actions/checkout@v3
         with:
@@ -33,6 +29,7 @@ jobs:
       -
         name: Update documentation
         run: |
+          python -m pip install -U pyyaml
           python .github/scripts/autodoc.py .github/workflows/workflow.yaml README.md
 
           # Exit early if no changes were made

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,7 @@ jobs:
       working-directory: ./test/terraform
       runs-on: ubuntu-latest
       terraform-docs-fail-on-diff: false
+      workflow-ref: "${{ github.sha }}"
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
       ssh-private-key: ${{ secrets.SSH_KEY_GITHUB_ACTIONS }}
@@ -29,6 +30,7 @@ jobs:
       trivy-error-is-success: true
       working-directory: ./test/trivy
       runs-on: ubuntu-latest
+      workflow-ref: "${{ github.sha }}"
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
       ssh-private-key: ${{ secrets.SSH_KEY_GITHUB_ACTIONS }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,8 +7,6 @@ on:
     paths-ignore:
       - '**/*.md'
 
-
-
 jobs:
   # Runs both Terraform checks and Trivy scan against a valid configuration.
   terraform-valid:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -85,6 +85,10 @@ on:
         description: Generate documentation recursively for all modules in the working directory.
         type: boolean
         default: false
+      workflow-ref:
+        description: "Internal: Specify the Git ref to use when the workflow is checking out its own repository. Pass an empty string for auto-detection."
+        type: string
+        default: ""
       # Toggles used for setting environment variables in this workflow.
       # It is not possible to pass env vars directly to reusable workflows.
       enable-azurerm-3-beta-resources:
@@ -428,6 +432,13 @@ jobs:
         id: workflow_tag
         shell: bash
         run: |
+          # Skip auto-detection if input is specified
+          if [[ -n "${{ inputs.workflow-ref }}" ]]
+          then
+            echo "workflow_tag=${{ inputs.workflow-ref }}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           pip3 install yq
           workflow_file="${GITHUB_WORKFLOW}"
           if ! [ -f "${workflow_file}" ]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ uses: nrkno/github-workflow-terraform-config/.github/workflows/workflow.yaml@v2
 - `terraform-docs-git-push` (boolean, default `true`) - Automatically push the commit to the pull request branch.
 - `terraform-docs-fail-on-diff` (boolean, default `true`) - Internal: Fail if there are changes in the documentation.
 - `terraform-docs-recursive` (boolean, default `false`) - Generate documentation recursively for all modules in the working directory.
+- `workflow-ref` (string, default `""`) - Internal: Specify the Git ref to use when the workflow is checking out its own repository. Pass an empty string for auto-detection.
 - `enable-azurerm-3-beta-resources` (boolean, default `false`) - Set the environment variable `ARM_THREEPOINTZERO_BETA_RESOURCES=true` when running the Terraform CLI.
 
 ### Secrets


### PR DESCRIPTION
This new input allows us to test the workflow with the same repository ref as the pull request.