### PR TITLE
feat!: modify workflow to use github app token

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,11 @@ on:
     paths-ignore:
       - '**/*.md'
 
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
 jobs:
   # Runs both Terraform checks and Trivy scan against a valid configuration.
   terraform-valid:
@@ -16,9 +21,6 @@ jobs:
       runs-on: ubuntu-latest
       terraform-docs-fail-on-diff: false
       workflow-ref: "${{ github.sha }}"
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
-      ssh-private-key: ${{ secrets.SSH_KEY_GITHUB_ACTIONS }}
 
   # Runs Trivy scan against a vulnerable config.
   trivy-invalid:
@@ -29,6 +31,3 @@ jobs:
       working-directory: ./test/trivy
       runs-on: ubuntu-latest
       workflow-ref: "${{ github.sha }}"
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
-      ssh-private-key: ${{ secrets.SSH_KEY_GITHUB_ACTIONS }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -98,12 +98,6 @@ on:
     secrets:
       registries:
         required: false
-      ssh-private-key:
-        required: true
-      ssh-private-key-docs-push:
-        required: false
-      token:
-        required: true
 
 name: Terraform
 jobs:
@@ -112,25 +106,6 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     if: inputs.terraform-job-enabled
     steps:
-      # Work-around for not being able to test if a secret has been set when
-      # using `if` for conditional step execution.
-      - name: Determine need for SSH agent
-        id: ssh-agent-test
-        shell: bash
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.ssh-private-key }}
-        run: |
-          set +e
-          test -n "${SSH_PRIVATE_KEY}"
-          echo "exit_code=${?}" >> $GITHUB_OUTPUT
-
-      # SSH agent used to checkout Terraform modules from other private repos on Github.
-      - name: Setup SSH agent
-        uses: webfactory/ssh-agent@v0.7.0
-        if: steps.ssh-agent-test.outputs.exit_code == '0'
-        with:
-          ssh-private-key: ${{ secrets.ssh-private-key }}
-
       - name: Configure secrets
         shell: bash
         env:
@@ -145,6 +120,17 @@ jobs:
             echo "Setting ${tokenvar} for ${domain}"
             echo "${tokenvar}=${token}" >> "${GITHUB_ENV}"
           done
+
+      - name: Get terraform checkout credentials
+        id: credentials
+        shell: bash
+        run: |
+          set -e
+
+          GITHUB_TOKEN=$(curl -sSL --fail -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r ".value")
+          token=$(curl -sS --fail -H "Authorization: Bearer $GITHUB_TOKEN" https://terraform-consumer.plattform-public.eno.k8s.az.nrk.cloud/v1/github/workflow_terraform_token)
+          terraform_token=$(jq -r .token <<<$token)
+          echo "terraform_token=$terraform_token" >> "$GITHUB_OUTPUT"
 
       - name: Configure environment
         run: |
@@ -208,6 +194,27 @@ jobs:
           echo "exit_code=${?}" >> $GITHUB_OUTPUT
         continue-on-error: true
 
+      - name: 'Run: setup git credentials'
+        id: credentials_setup
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          TOKEN: ${{ steps.credentials.outputs.terraform_token }}
+        run: |
+          set +e
+
+          credentials_dir=$(mktemp -d)
+          echo "git_credentials_dir=${credentials_dir}" >> "${GITHUB_OUTPUT}"
+          if [ -f ~/.gitconfig ]
+          then
+            cp ~/.gitconfig "${credentials_dir}/"
+          fi
+          echo "https://x-access-token:${TOKEN}@github.com" > "${credentials_dir}/credentials"
+          git config --global credential.helper "store --file=${credentials_dir}/credentials"
+          git config --global --replace-all 'url.https://github.com/.insteadOf' 'ssh://git@github.com/'
+          git config --global --add 'url.https://github.com/.insteadOf' 'git@github.com:'
+          cat ~/.gitconfig
+
       - name: 'Run: terraform init'
         id: init
         shell: bash
@@ -217,6 +224,24 @@ jobs:
           terraform init -no-color -backend=false
           echo "exit_code=${?}" >> $GITHUB_OUTPUT
         continue-on-error: true
+
+      - name: 'Run: cleanup setup git'
+        id: credentials_cleanup
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          GIT_CREDENTIALS_DIR: ${{ steps.credentials_setup.outputs.git_credentials_dir }}
+        run: |
+          set +e
+
+          if [ -f "${GIT_CREDENTIALS_DIR}/.gitconfig" ]
+          then
+            cp "${GIT_CREDENTIALS_DIR}/.gitconfig" ~/.gitconfig
+          else
+            rm ~/.gitconfig
+          fi
+          shred -u "${GIT_CREDENTIALS_DIR}/credentials"
+          rm -r -- "${GIT_CREDENTIALS_DIR}"
 
         # workaround for https://github.com/hashicorp/terraform/issues/28490
       - uses: actions/setup-go@v3
@@ -403,30 +428,21 @@ jobs:
     needs: [terraform]
     concurrency: terraform-docs
     steps:
-      - name: Check ssh key for checkout and push
-        id: ssh_key_check
+      - name: Get terraform docs credentials
+        id: credentials
         shell: bash
-        env:
-          SSH_PRIVATE_KEY: "${{ secrets.ssh-private-key-docs-push }}"
         run: |
-          set +e
-          if test -n "${SSH_PRIVATE_KEY}"
-          then
-            echo "has_ssh_key=yes" >> $GITHUB_OUTPUT
-          else
-            echo "has_ssh_key=no" >> $GITHUB_OUTPUT
-          fi
+          set -e
+
+          GITHUB_TOKEN=$(curl -sSL --fail -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r ".value")
+          token=$(curl -sS --fail -H "Authorization: Bearer $GITHUB_TOKEN" https://terraform-consumer.plattform-public.eno.k8s.az.nrk.cloud/v1/github/workflow_terraform_docs_token)
+          terraform_docs_token=$(jq -r .token <<<$token)
+          echo "terraform_docs_token=$terraform_docs_token" >> "$GITHUB_OUTPUT"
       - name: Checkout
         uses: actions/checkout@v3
-        if: ${{ steps.ssh_key_check.outputs.has_ssh_key == 'yes' }}
         with:
           ref: "${{ github.head_ref }}"
-          ssh-key: "${{ secrets.ssh-private-key-docs-push }}"
-      - name: Checkout
-        uses: actions/checkout@v3
-        if: ${{ steps.ssh_key_check.outputs.has_ssh_key  != 'yes' }}
-        with:
-          ref: "${{ github.head_ref }}"
+          token: ${{ steps.credentials.outputs.terraform_docs_token }}
       - uses: actions/setup-python@v4
       - name: Get workflow ref
         id: workflow_tag
@@ -483,7 +499,7 @@ jobs:
           output-method: ${{ inputs.terraform-docs-output-method }}
           git-push: false
       - name: Commit doc updates
-        if: ${{ steps.ssh_key_check.outputs.has_ssh_key == 'yes' && inputs.terraform-docs-git-push }}
+        if: ${{ inputs.terraform-docs-git-push }}
         shell: bash
         env:
           COMMIT_MESSAGE: ${{ inputs.terraform-docs-git-commit-message }}

--- a/README.md
+++ b/README.md
@@ -48,9 +48,6 @@ uses: nrkno/github-workflow-terraform-config/.github/workflows/workflow.yaml@v2
 
 ### Secrets
 - `registries`
-- `ssh-private-key` (**required**)
-- `ssh-private-key-docs-push`
-- `token` (**required**)
 <!-- autodoc end -->
 
 ## Developing

--- a/README.md
+++ b/README.md
@@ -4,7 +4,14 @@ Reusable GitHub workflow for validating a Terraform configuration repository.
 
 ## Usage
 
+You must set permissions in order to add the required id-token permissions which is off by default.
+
 ```yaml
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
 name: Terraform
 uses: nrkno/github-workflow-terraform-config/.github/workflows/workflow.yaml@v2
   with:
@@ -45,63 +52,6 @@ uses: nrkno/github-workflow-terraform-config/.github/workflows/workflow.yaml@v2
 - `ssh-private-key-docs-push`
 - `token` (**required**)
 <!-- autodoc end -->
-
-## Setting up automatic push of terraform documentation updates
-
-In order to get updates of terraform documentation to trigger new workflows, the
-git push must be done using a ssh deploy key and not the build in github token.  
-For repos that is [iac-terraform-modules](https://github.com/nrkno/iac-terraform-module-template) (containing topics: `terraform` and `terraform-module`) this will be applied with `terraform plan/apply` on plattform-config repo automaticly
-For other repos you first need to generate a new ssh key pair and add build secrets:
-```bash
-ssh-keygen -f id_ed25519 -t ed25519 -N "" -C "terraform-docs"
-gh repo deploy-key add -w -t "terraform docs push" id_ed25519.pub
-gh secret set SSH_KEY_TERRAFORM_DOCS -b "$(cat id_ed25519)"
-gh secret set SSH_KEY_TERRAFORM_DOCS -b "$(cat id_ed25519)" --app dependabot
-shred -u id_ed25519*
-```
-
-It is allso posible to do this with terraform if you want to manage the keys yourself:   
-```HCL
-# Generate Deploy-key and public-key and insert into vault
-module "plattform-terraform-docs-ssh-key" {
-  source  = "terraform-registry.nrk.cloud/nrkno/iac-terraform-tls-key/generic"
-  version = "1.0.0"
-
-  algorithm = "RSA"
-  rsa_bits  = 4096
-  lastpass  = false
-  vault     = true
-  path      = "path-to/location-in/vault-to/place-the/key-and/public-key"
-
-  providers = {
-    lastpass = lastpass
-    vault    = vault
-  }
-}
-
-# Add public key as deploy-key to repo
-resource "github_repository_deploy_key" "terraform-docs-deploy-key" {
-  title      = "terraform-docs-ssh-key"
-  repository = "nrkno/<repo-name>"
-  key        = module.plattform-terraform-docs-ssh-key.tls_public_key_openssh
-  read_only  = true
-}
-
-# Add key as secret for repo
-resource "github_actions_secret" "terraform-docs-deploy-key" {
-  repository      = "nrkno/<repo-name>"
-  secret_name     = "SSH_KEY_TERRAFORM_DOCS"
-  plaintext_value = module.plattform-terraform-docs-ssh-key.tls_key_pem
-}
-```
-Then change inputs for the workflow and set
-```yaml
-    with:
-      ...
-      terraform-docs-fail-on-diff: false
-    secrets:
-      ssh-private-key-docs-push: ${{ secrets.SSH_KEY_TERRAFORM_DOCS }}
-```
 
 ## Developing
 


### PR DESCRIPTION
Use new terraform github app for credentials, this removes the need for ssh credentials.
Since all users of this workflow must be updated, this is a breaking change.

Tested in: https://github.com/nrkno/iac-terraform-kubernetes-nrk-sso/pull/2