### PR TITLE
fix: use outputs instead of env for workflow secrets

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -118,6 +118,7 @@ jobs:
             IFS="=" read domain token <<<$registry
             tokenvar="TF_TOKEN_$(tr . _ <<<$domain | sed s/-/__/g)"
             echo "Setting ${tokenvar} for ${domain}"
+            echo "::add-mask::${token}"
             echo "${tokenvar}=${token}" >> "${GITHUB_ENV}"
           done
 


### PR DESCRIPTION
Testet og fungerer for nrkno-terraform-config https://github.com/nrkno/nrkno-terraform-config/actions/runs/4312429745/jobs/7523405193
