### PR TITLE
fix: temporarily default to tf version to v1.4.0

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -8,7 +8,7 @@ on:
       terraform-version:
         description: Version of Terraform to use
         type: string
-        default: latest
+        default: v1.4.0
       working-directory:
         description: Working directory for all workflow operations, unless documented otherwise.
         type: string

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ uses: nrkno/github-workflow-terraform-config/.github/workflows/workflow.yaml@v4.
 <!-- autodoc start -->
 ### Inputs
 - `terraform-job-enabled` (boolean, default `true`) - Enable the Terraform checks
-- `terraform-version` (string, default `"latest"`) - Version of Terraform to use
+- `terraform-version` (string, default `"v1.4.0"`) - Version of Terraform to use
 - `working-directory` (string, default `"."`) - Working directory for all workflow operations, unless documented otherwise.
 - `terraform-ignore-files` (string, default `""`) - Comma-separated list of filepaths to remove before running Terraform operations. This is relative to the working-directory argument.
 - `status-comment-enabled` (boolean, default `true`) - Post a status comment in the pull request issue after checks have completed.


### PR DESCRIPTION
A [bug in Terraform v1.4.1](https://github.com/hashicorp/terraform/issues/32853) breaks some usage of `setproduct`. Temporarily defaulting to v1.4.0 instead.