### PR TITLE
fix!: change default runner infrastructure

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -28,7 +28,7 @@ on:
       runs-on:
         description: Defines the type of machine to run the jobs on.
         type: string
-        default: nrk-azure-intern
+        default: ubuntu-latest
       trivy-job-enabled:
         description: Scan repository for IaC vulnerabilities using Trivy.
         type: boolean


### PR DESCRIPTION
Bytter default kjøremiljø fra self-hosted til Github hosted for å redusere last på det ustabile Azure-kjøremiljøet.
BREAKING: Workflows som må kjøre denne på intern sone, må nå eksplisitt sette _nrk-azure-intern_ som et argument